### PR TITLE
Add new tools: fund-my-watcard and US Intern's Guide

### DIFF
--- a/data/10-general.json
+++ b/data/10-general.json
@@ -10,23 +10,6 @@
     },
     {
       "Name": {
-        "text": "Waterloo Tools",
-        "url": "https://wattools.ca/"
-      },
-      "Source Code": {
-        "text": "github",
-        "url": "https://github.com/wattools/WatTools"
-      },
-      "Author": {
-        "text": "Viktor Stanchev",
-        "url": "http://viktorstanchev.com"
-      },
-      "Description": {
-        "text": "A collection of tools for University of Waterloo students made by other students."
-      }
-    },
-    {
-      "Name": {
         "text": "UW Living",
         "url": "https://www.uwliving.com/"
       },
@@ -36,6 +19,22 @@
       },
       "Description": {
         "text": "Reviews for student housing in Waterloo."
+      }
+    },
+    {
+      "Name": {
+        "text": "fund-my-watcard",
+        "url": "https://pypi.org/project/fund-my-watcard/"
+      },
+      "Description": {
+        "text": "A tool helps you add funds to your WatCard easily."
+      },
+      "Source Code": {
+        "text": "Find us on github",
+        "url": "https://github.com/xingweitian/fund-my-watcard"
+      },
+      "Authors": {
+        "text": "Weitian Xing, Kevin Lu, Yuxin Fan"
       }
     }
   ]

--- a/data/60-guides.json
+++ b/data/60-guides.json
@@ -28,6 +28,22 @@
         "text": "Stephen Holiday",
         "url": "http://stephenholiday.com\/"
       }
+    },
+    {
+      "Name": {
+        "text": "The Meticulous US Intern's Guide",
+        "url": "https://anthony-zhang.me/blog/intern-101/"
+      },
+      "Description": {
+        "text": "A detailed to-do list for US internships, from the moment you have an offer to when you’re filing your taxes the year after."
+      },
+      "Source Code": {
+        "text": "github",
+        "url": "https://github.com/Uberi/uberi.github.io/tree/master/blog/intern-101"
+      },
+      "Authors": {
+        "text": "Anthony Zhang"
+      }
     }
   ]
 }


### PR DESCRIPTION
Closes https://github.com/wattools/WatTools/issues/59, closes https://github.com/wattools/WatTools/issues/70.

Also removed WatTools from the `General` category. Linking to the very page the user is on is a bit too tongue in cheek.